### PR TITLE
Adding test on other decorator declaration.

### DIFF
--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -1,3 +1,4 @@
+import exp from 'constants';
 import { TS2Famix } from '../src/ts2famix';
 
 const filePaths = ["test_src/Decorators.ts"];
@@ -20,5 +21,12 @@ describe('ts2famix', () => {
     it("should contain a class with the classDec decorator", async () => {
         const decorator = parsedModel.filter(el => (el.FM3 == "FamixTypeScript.Decorator" && el.name == "classDec"))[0];
         expect(decorator.name).toBe("classDec");
+        expect(decorator.decoratorType).toBe("Class");
+    })
+
+    it("should contain a method with the methodDec decorator", async () => {
+        const decorator = parsedModel.filter(el => (el.FM3 == "FamixTypeScript.Decorator" && el.name == "methodDec"))[0];
+        expect(decorator.name).toBe("methodDec");
+        expect(decorator.decoratorType).toBe("Method");
     })
 });

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -29,4 +29,10 @@ describe('ts2famix', () => {
         expect(decorator.name).toBe("methodDec");
         expect(decorator.decoratorType).toBe("Method");
     })
+
+    it("should contain a accessor with the accessorDec decorator", async () => {
+        const decorator = parsedModel.filter(el => (el.FM3 == "FamixTypeScript.Decorator" && el.name == "accessorDec"))[0];
+        expect(decorator.name).toBe("accessorDec");
+        expect(decorator.decoratorType).toBe("Accessor");
+    })
 });

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -41,4 +41,10 @@ describe('ts2famix', () => {
         expect(decorator.name).toBe("propertyDec");
         expect(decorator.decoratorType).toBe("Property");
     })
+
+    it("should contain a parameterDec with the parameterDec decorator", async () => {
+        const decorator = parsedModel.filter(el => (el.FM3 == "FamixTypeScript.Decorator" && el.name == "parameterDec"))[0];
+        expect(decorator.name).toBe("parameterDec");
+        expect(decorator.decoratorType).toBe("Parameter");
+    })
 });

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -1,5 +1,4 @@
 import { TS2Famix } from '../src/ts2famix';
-import 'jest-extended';
 
 const filePaths = ["test_src/Decorators.ts"];
 const importer = new TS2Famix();
@@ -19,7 +18,7 @@ describe('ts2famix', () => {
     initMapFromModel(parsedModel);
 
     it("should contain a class with the classDec decorator", async () => {
-        const decorator = parsedModel.filter(el => (el.FM3 == "FamixTypeScript.AnnotationType" && el.name == "classDec"))[0];
+        const decorator = parsedModel.filter(el => (el.FM3 == "FamixTypeScript.Decorator" && el.name == "classDec"))[0];
         expect(decorator.name).toBe("classDec");
     })
 });

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -35,4 +35,10 @@ describe('ts2famix', () => {
         expect(decorator.name).toBe("accessorDec");
         expect(decorator.decoratorType).toBe("Accessor");
     })
+
+    it("should contain a property with the propertyDec decorator", async () => {
+        const decorator = parsedModel.filter(el => (el.FM3 == "FamixTypeScript.Decorator" && el.name == "propertyDec"))[0];
+        expect(decorator.name).toBe("propertyDec");
+        expect(decorator.decoratorType).toBe("Property");
+    })
 });

--- a/test_src/Decorators.ts
+++ b/test_src/Decorators.ts
@@ -1,10 +1,45 @@
 
-function classDec(target){
+const classDec = (target) => {
+    return;
+}
+
+const methodDec = () => {
+    return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+        return;
+    };
+}
+
+const accessorDec = () => {
+    return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+        return;
+    };
+}
+
+const propertyDec = (value: string) => {
+        return (target: any, propertyKey: string) => {
+            return;
+        };
+}
+
+const parameterDec = (target: Object, propertyKey: string | symbol, parameterIndex: number) => {
     return;
 }
 
 @classDec
 class SimpleDecoratorClass{
-    
+    private _accessor: number;
+
+    @propertyDec("value")
+    classProperty: string;
+
+    @accessorDec()
+    get accessor(){
+        return this._accessor;
+    }
+
+    @methodDec()
+    decoratedMethod(@parameterDec param: boolean){
+        return;
+    }
 }
 


### PR DESCRIPTION
Tests were added for declarators applied on the following type of declarations:

1. Class
2. Method
3. Accessor
4. Property
5. Parameter

![image](https://user-images.githubusercontent.com/56443178/155221034-211032b8-a703-40de-a5d9-e4e72c2da3f3.png)

These tests should all pass in order to correctly implement the decorator entity in the TS2Famix importer. As you can see, there is only the accessor decorator left to implement. 

Upon looking at the code, the accessor decorator may be trickier. We might have to redefine the scope of our modification. Until then, the test stays in a effort towards TDD.

P.S.
you can run the tests with the "npm run test" command. I use the extension Jest Runner in VS Code it allows to debug the tests easily.